### PR TITLE
APIの返り値によって音楽のURLをLINEに返す処理を実装、音楽のURLのリストを追加

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -15,6 +15,9 @@ class WebhookController < ApplicationController
   def callback
     body = request.body.read
 
+    audio_positive_list = ['https://www.youtube.com/watch?v=TW9d8vYrVFQ','https://www.youtube.com/watch?v=HZd-vLLeSt0']
+    audio_negative_list = ['https://www.youtube.com/watch?v=0kqyGvc_WNA','https://www.youtube.com/watch?v=faf98cNY8A8']
+
     signature = request.env['HTTP_X_LINE_SIGNATURE']
     unless client.validate_signature(body, signature)
       head 470
@@ -39,10 +42,18 @@ class WebhookController < ApplicationController
             label = response_sentiment['scored_labels'][0]['label']
             score = response_sentiment['scored_labels'][0]['score']
 
-            # 今回はスコアのみをユーザーに送り返す
+            # 今回は値に応じて特定の一曲を返すように実装
+            if label == 'POSITIVE'
+              audio_url = score > 0.5 ? audio_positive_list[0] : audio_positive_list[1]
+            
+            elsif label == 'NEGATIVE'
+              audio_url = score > 0.5 ? audio_negative_list[0] : audio_negative_list[1]
+            
+            end
+
             message = {
               type: 'text',
-              text: score
+              text: audio_url
             }
 
           # 429エラー用の処理

--- a/app/errors/unexpected_api_response_error.rb
+++ b/app/errors/unexpected_api_response_error.rb
@@ -1,0 +1,5 @@
+class UnexpectedApiResponseError < StandardError
+    def initialize(msg="想定されていたlabelではありませんでした。")
+        super(msg)
+    end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,5 +16,8 @@ module RubyGettingStarted
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
 
+    # 作成したカスタム例外を使えるように追加
+    config.autoload_paths += Dir.glob("#{config.root}/app/errors")
+
   end
 end


### PR DESCRIPTION
## 実装の背景・目的

感情分析された結果の返り値に応じて、特定の音楽のURLをLINEに返すようにコードを追加した。

## やったこと

- 音楽のURLが入ったリストの追加（POSITIVE、NEGATIVEごとにリストを作成）
- label（今回のAPIの場合だとPOSITIVEかNEGATIVE）の値に応じて処理を分岐
- scoreに応じてリストから特定のURLを取得
- 取得したURLをLINEに返すように実装

## キャプチャ

![IMG_1238](https://github.com/Rei1449/intern-line-bot/assets/129351823/e1417b50-5bc4-45d6-b034-538be6eb662c)


## 補足

- 音楽リストは時間があれば拡張したいと考えており、現段階の時点でPOSITIVEとNEGATIVEで分けている。
- 今回選んだ音楽は定性的なもののため、定量的なデータがあれば、それを加味した上で新たにURLを選定する予定
